### PR TITLE
Migrate to SvelteKit

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,8 @@
+<script>
+  import Header from '../components/Header.svelte';
+  import Sidebar from '../components/Sidebar.svelte';
+</script>
+
+<Header />
+<Sidebar />
+<slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Dashboard from '../containers/Dashboard.svelte';
+</script>
+
+<Dashboard />

--- a/src/routes/apps/+page.svelte
+++ b/src/routes/apps/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Apps from '../../../containers/apps/Apps.svelte';
+</script>
+
+<Apps />

--- a/src/routes/apps/details/[appName]/+page.svelte
+++ b/src/routes/apps/details/[appName]/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import AppDetails from '../../../../containers/apps/appDetails/AppDetails.svelte';
+</script>
+
+<AppDetails />

--- a/src/routes/apps/oneclick/+page.svelte
+++ b/src/routes/apps/oneclick/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import OneClickAppSelector from '../../../containers/apps/oneclick/selector/OneClickAppSelector.svelte';
+</script>
+
+<OneClickAppSelector />

--- a/src/routes/apps/oneclick/[appName]/+page.svelte
+++ b/src/routes/apps/oneclick/[appName]/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import OneClickAppConfigPage from '../../../../containers/apps/oneclick/variables/OneClickAppConfigPage.svelte';
+</script>
+
+<OneClickAppConfigPage />

--- a/src/routes/cluster/+page.svelte
+++ b/src/routes/cluster/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Cluster from '../../containers/nodes/Cluster.svelte';
+</script>
+
+<Cluster />

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Login from '../../containers/Login.svelte';
+</script>
+
+<Login />

--- a/src/routes/maintenance/+page.svelte
+++ b/src/routes/maintenance/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Maintenance from '../../containers/maintenance/Maintenance.svelte';
+</script>
+
+<Maintenance />

--- a/src/routes/monitoring/+page.svelte
+++ b/src/routes/monitoring/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Monitoring from '../../containers/monitoring/Monitoring.svelte';
+</script>
+
+<Monitoring />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Settings from '../../containers/settings/Settings.svelte';
+</script>
+
+<Settings />


### PR DESCRIPTION
Migrate the front end project to SvelteKit.

* **Layout and Routing**
  - Add `src/routes/+layout.svelte` to create a new SvelteKit layout component.
  - Add `src/routes/+page.svelte` to create a new SvelteKit page component for the dashboard.
  - Add `src/routes/apps/+page.svelte` to create a new SvelteKit page component for the apps page.
  - Add `src/routes/apps/details/[appName]/+page.svelte` to create a new SvelteKit page component for the app details page.
  - Add `src/routes/apps/oneclick/+page.svelte` to create a new SvelteKit page component for the one-click app selector page.
  - Add `src/routes/apps/oneclick/[appName]/+page.svelte` to create a new SvelteKit page component for the one-click app config page.
  - Add `src/routes/cluster/+page.svelte` to create a new SvelteKit page component for the cluster page.
  - Add `src/routes/maintenance/+page.svelte` to create a new SvelteKit page component for the maintenance page.
  - Add `src/routes/monitoring/+page.svelte` to create a new SvelteKit page component for the monitoring page.
  - Add `src/routes/settings/+page.svelte` to create a new SvelteKit page component for the settings page.
  - Add `src/routes/login/+page.svelte` to create a new SvelteKit page component for the login page.

